### PR TITLE
accept space in codeNature

### DIFF
--- a/src/shared/infrastructure/dto/metadonnees.dto.ts
+++ b/src/shared/infrastructure/dto/metadonnees.dto.ts
@@ -318,13 +318,13 @@ export class MetadonneesDto {
   libelleNAC: string
 
   @ApiPropertyOptional({
-    description: "Complément d'information du code NAC. Au format : ^[0-9a-zA-Z]{0,2}$",
+    description: "Complément d'information du code NAC. Au format : ^[0-9a-zA-Z ]{0,2}$",
     type: String,
     example: metadonneesDtoExample.codeNature
   })
   @IsOptional()
   @IsString()
-  @Matches('^[0-9a-zA-Z]{0,2}$')
+  @Matches('^[0-9a-zA-Z ]{0,2}$')
   codeNature?: string
 
   @ApiPropertyOptional({


### PR DESCRIPTION
Pour une raison que j'ignore il n'y a pas plus de contraintes sur le codeNature dans [dbsder-api](https://github.com/Cour-de-cassation/dbsder-api/blob/eab8654db88fe241d3671dd4c5046815fce1f5ba/src/infrastructure/dto/createDecision.dto.ts#L509) que `string`, contrairement au codeService qui a la même regex que dans juritj ==> pas de modifs nécéssaires dans l'API dbsder pour accepter les espaces dans le codeNature

