### PR TITLE
Improve/fix motivationOccultation logic

### DIFF
--- a/documentation/filtrage.md
+++ b/documentation/filtrage.md
@@ -47,7 +47,7 @@ Voici les critères que les métadonnées doivent respecter pour que la décisio
 | libelleNature             | string           | Non         | -                                                                          |
 | decisionPublique          | boolean          | Oui         | -                                                                          |
 | recommandationOccultation | complexe         | Oui         | Uniquement les valeurs 'conforme', 'aucune', 'substituant' ou 'complément' |
-| occultationComplementaire | string           | Non         | -                                                                          |
+| occultationComplementaire | string           | Non         | Champ libre pour transmettre des consignes d'occultation supplémentaires   |
 | selection                 | boolean          | Oui         | -                                                                          |
 | matiereDeterminee         | boolean          | Oui         | -                                                                          |
 | pourvoiLocal              | boolean          | Oui         | -                                                                          |

--- a/src/batch/normalization/services/computeOccultation.spec.ts
+++ b/src/batch/normalization/services/computeOccultation.spec.ts
@@ -93,7 +93,7 @@ describe('compute occultation', () => {
     expect(response).toEqual(expectedResponse)
   })
 
-  it('returns motivationOccultation true when debat are not public', () => {
+  it('returns motivationOccultation true when debat are not public and recommandationOccultation are followed (conforme or complémentaire)', () => {
     // GIVEN
     const debatPublic = false
     const providedRecommandationOccultation = Occultation.COMPLEMENT
@@ -101,6 +101,27 @@ describe('compute occultation', () => {
       additionalTerms: providedOccultationComplementaire,
       categoriesToOmit: [],
       motivationOccultation: true
+    }
+
+    // WHEN
+    const response = computeOccultation(
+      providedRecommandationOccultation,
+      providedOccultationComplementaire,
+      debatPublic
+    )
+
+    // THEN
+    expect(response).toEqual(expectedResponse)
+  })
+
+  it('returns motivationOccultation false when recommandationOccultation are not followed (aucune or substituant)', () => {
+    // GIVEN
+    const debatPublic = false
+    const providedRecommandationOccultation = Occultation.AUCUNE
+    const expectedResponse: DecisionOccultation = {
+      additionalTerms: '',
+      categoriesToOmit: [],
+      motivationOccultation: false
     }
 
     // WHEN

--- a/src/batch/normalization/services/computeOccultation.ts
+++ b/src/batch/normalization/services/computeOccultation.ts
@@ -24,13 +24,20 @@ export function computeOccultation(
     msg: `additionalTerms computed`
   })
 
+  const motivationOccultation =
+    recommandationOccultation === Occultation.AUCUNE ||
+    recommandationOccultation === Occultation.SUBSTITUANT
+      ? false
+      : !debatPublic
+
+  logger.info({
+    ...formatLogs,
+    msg: `motivationOccultation computed ${motivationOccultation}`
+  })
+
   return {
     additionalTerms,
     categoriesToOmit: [],
-    motivationOccultation:
-      recommandationOccultation === Occultation.AUCUNE ||
-      recommandationOccultation === Occultation.SUBSTITUANT
-        ? false
-        : !debatPublic
+    motivationOccultation
   }
 }

--- a/src/batch/normalization/services/computeOccultation.ts
+++ b/src/batch/normalization/services/computeOccultation.ts
@@ -4,8 +4,8 @@ import { LogsFormat } from '../../../shared/infrastructure/utils/logsFormat.util
 
 export function computeOccultation(
   recommandationOccultation: string,
-  occultationComplementaire: string,
-  denatPublic: boolean
+  occultationSupplementaire: string,
+  debatPublic: boolean
 ): DecisionOccultation {
   const formatLogs: LogsFormat = {
     ...normalizationFormatLogs,
@@ -16,17 +16,21 @@ export function computeOccultation(
   const additionalTerms =
     recommandationOccultation === Occultation.SUBSTITUANT ||
     recommandationOccultation === Occultation.COMPLEMENT
-      ? occultationComplementaire
+      ? occultationSupplementaire
       : ''
 
   logger.info({
     ...formatLogs,
-    msg: `additionalTerms computed: ${additionalTerms}`
+    msg: `additionalTerms computed`
   })
 
   return {
     additionalTerms,
     categoriesToOmit: [],
-    motivationOccultation: !denatPublic
+    motivationOccultation:
+      recommandationOccultation === Occultation.AUCUNE ||
+      recommandationOccultation === Occultation.SUBSTITUANT
+        ? false
+        : !debatPublic
   }
 }


### PR DESCRIPTION
- ne pas occulter les motivations d'une décisions si les recommandations d'occultation de la Cour ne sont pas suivies (Aucune ou Substituant)
- retirer le log des additionalTerms qui peut contenir des données sensibles
- changement sémantique dans la fonction `computeOccultation` : dans le swagger le champ libre de consignes d'occultation est appelé `occultationComplementaire` alors que ce sont des occultations supplémentaires. Le swagger reste inchangé pour ne pas demander d'évolution aux consommateur de l'API.