### PR TITLE
Feat/log harmoniz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ docker.env
 
 # Wordperfect Documents
 *.wpd
+.vscode

--- a/src/api/infrastructure/controllers/decisions/decisions.controller.ts
+++ b/src/api/infrastructure/controllers/decisions/decisions.controller.ts
@@ -36,7 +36,8 @@ import {
 import { BucketError } from '../../../../shared/domain/errors/bucket.error'
 import { InfrastructureExpection } from '../../../../shared/infrastructure/exceptions/infrastructure.exception'
 import { UnexpectedException } from '../../../../shared/infrastructure/exceptions/unexpected.exception'
-import { LogsFormat } from '../../../../shared/infrastructure/utils/logsFormat.utils'
+import { TechLog } from '../../../../shared/infrastructure/utils/logsFormat.utils'
+import { logger } from '../../../../shared/infrastructure/utils/pinoConfig.utils'
 
 const FILE_MAX_SIZE = {
   size: 10000000,
@@ -51,7 +52,6 @@ export interface CollecteDecisionResponse {
 @ApiTags('Collect')
 @Controller('decisions')
 export class DecisionsController {
-  private readonly logger = new Logger()
   private readonly decisionMongoRepository = new DecisionMongoRepository()
 
   @Post()
@@ -90,31 +90,42 @@ export class DecisionsController {
     const routePath = request.method + ' ' + request.path
 
     const decisionUseCase = new SaveDecisionUsecase(
-      new DecisionS3Repository(this.logger),
+      new DecisionS3Repository(logger),
       this.decisionMongoRepository
     )
-    const formatLogs: LogsFormat = {
-      operationName: 'collectDecisions',
-      httpMethod: request.method,
-      path: request.path,
-      msg: `Starting ${routePath}...`,
-      correlationId: request.headers['x-correlation-id']
+
+    // techlog car pas de sourceId à ce niveau, nous avons juste le correlationId pour suivre la requête dans les logs
+    const formatLogs: TechLog = {
+      path: 'src/api/infrastructure/controllers/decisions/decisions.controller.ts',
+      operations: ['collect', 'decisions'],
+      message: JSON.stringify({
+        httpMethod: request.method,
+        path: request.path,
+        msg: `Starting ${routePath}...`,
+        correlationId: request.headers['x-correlation-id']
+      })
     }
+    logger.info(formatLogs)
+
     const filename = await decisionUseCase
       .execute(decisionIntegre, metadonneesDto)
       .catch((error) => {
         if (error instanceof BucketError) {
-          this.logger.error({
+          logger.error({
             ...formatLogs,
-            msg: error.message,
-            statusCode: HttpStatus.SERVICE_UNAVAILABLE
+            message: JSON.stringify({
+              msg: error.message,
+              statusCode: HttpStatus.SERVICE_UNAVAILABLE
+            })
           })
           throw new InfrastructureExpection(error.message)
         }
-        this.logger.error({
+        logger.error({
           ...formatLogs,
-          msg: error.message,
-          statusCode: HttpStatus.INTERNAL_SERVER_ERROR
+          message: JSON.stringify({
+            msg: error.message,
+            statusCode: HttpStatus.INTERNAL_SERVER_ERROR
+          })
         })
         throw new UnexpectedException(error)
       })
@@ -123,11 +134,13 @@ export class DecisionsController {
     delete metadonneesDto['parties']
     delete metadonneesDto['president']
     delete metadonneesDto['sommaire']
-    this.logger.log({
+    logger.info({
       ...formatLogs,
-      msg: routePath + ' returns ' + HttpStatus.ACCEPTED,
-      data: { decision: metadonneesDto },
-      statusCode: HttpStatus.ACCEPTED
+      message: JSON.stringify({
+        msg: routePath + ' returns ' + HttpStatus.ACCEPTED,
+        data: { decision: metadonneesDto },
+        statusCode: HttpStatus.ACCEPTED
+      })
     })
 
     return { filename, body: 'Nous avons bien reçu la décision intègre et ses métadonnées.' }

--- a/src/api/infrastructure/controllers/decisions/decisions.controller.ts
+++ b/src/api/infrastructure/controllers/decisions/decisions.controller.ts
@@ -3,7 +3,6 @@ import {
   Controller,
   HttpCode,
   HttpStatus,
-  Logger,
   Post,
   Req,
   UploadedFile,

--- a/src/api/infrastructure/controllers/decisions/decisions.controller.ts
+++ b/src/api/infrastructure/controllers/decisions/decisions.controller.ts
@@ -89,7 +89,7 @@ export class DecisionsController {
     const routePath = request.method + ' ' + request.path
 
     const decisionUseCase = new SaveDecisionUsecase(
-      new DecisionS3Repository(logger),
+      new DecisionS3Repository(),
       this.decisionMongoRepository
     )
 

--- a/src/api/infrastructure/controllers/health/bucketHealthIndicator.ts
+++ b/src/api/infrastructure/controllers/health/bucketHealthIndicator.ts
@@ -1,18 +1,18 @@
-import { Injectable, Logger } from '@nestjs/common'
+import { Injectable } from '@nestjs/common'
 import { HealthIndicator, HealthIndicatorResult, HealthCheckError } from '@nestjs/terminus'
 import { DecisionS3Repository } from '../../../../shared/infrastructure/repositories/decisionS3.repository'
+import { logger } from '../../../../shared/infrastructure/utils/pinoConfig.utils'
 
 @Injectable()
 export class BucketHealthIndicator extends HealthIndicator {
   private key = 'bucket'
-  private readonly logger = new Logger()
 
   constructor() {
     super()
   }
 
   async isHealthy(): Promise<HealthIndicatorResult> {
-    const decisionS3Repository = new DecisionS3Repository(this.logger)
+    const decisionS3Repository = new DecisionS3Repository(logger)
     try {
       await decisionS3Repository.getDecisionList()
       return this.getStatus(this.key, true)

--- a/src/api/infrastructure/controllers/health/bucketHealthIndicator.ts
+++ b/src/api/infrastructure/controllers/health/bucketHealthIndicator.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import { HealthIndicator, HealthIndicatorResult, HealthCheckError } from '@nestjs/terminus'
 import { DecisionS3Repository } from '../../../../shared/infrastructure/repositories/decisionS3.repository'
-import { logger } from '../../../../shared/infrastructure/utils/pinoConfig.utils'
 
 @Injectable()
 export class BucketHealthIndicator extends HealthIndicator {
@@ -12,7 +11,7 @@ export class BucketHealthIndicator extends HealthIndicator {
   }
 
   async isHealthy(): Promise<HealthIndicatorResult> {
-    const decisionS3Repository = new DecisionS3Repository(logger)
+    const decisionS3Repository = new DecisionS3Repository()
     try {
       await decisionS3Repository.getDecisionList()
       return this.getStatus(this.key, true)

--- a/src/api/infrastructure/interceptors/logging.interceptor.ts
+++ b/src/api/infrastructure/interceptors/logging.interceptor.ts
@@ -1,7 +1,7 @@
 import { Request } from 'express'
 import { catchError, Observable, throwError } from 'rxjs'
 import { Injectable, ExecutionContext, CallHandler, NestInterceptor, Logger } from '@nestjs/common'
-import { LogsFormat } from '../../../shared/infrastructure/utils/logsFormat.utils'
+import { TechLog } from '../../../shared/infrastructure/utils/logsFormat.utils'
 
 @Injectable()
 export class LoggingInterceptor implements NestInterceptor {
@@ -11,12 +11,15 @@ export class LoggingInterceptor implements NestInterceptor {
     const request: Request = context.switchToHttp().getRequest()
     const routePath = request.method + ' ' + request.path
     const file = request.file ? request.file.originalname : 'no file'
-    const formatLogs: LogsFormat = {
-      operationName: 'intercept',
-      msg: routePath + ' received with ' + file + '.',
-      httpMethod: request.method,
-      path: request.path,
-      correlationId: request.headers['x-correlation-id']
+    const formatLogs: TechLog = {
+      operations: ['other', 'logging'],
+      path: './src/api/infrastructure/interceptors/logging.interceptor.ts',
+      message: JSON.stringify({
+        routePath: routePath + ' received with ' + file + '.',
+        httpMethod: request.method,
+        path: request.path,
+        correlationId: request.headers['x-correlation-id']
+      })
     }
 
     this.logger.log(formatLogs)
@@ -29,8 +32,10 @@ export class LoggingInterceptor implements NestInterceptor {
         const status = err.status || err
         this.logger.error({
           ...formatLogs,
-          msg: routePath + ' returns ' + status + ': ' + errorMessage,
-          statusCode: err.status || undefined
+          message: JSON.stringify({
+            msg: routePath + ' returns ' + status + ': ' + errorMessage,
+            statusCode: err.status || undefined
+          })
         })
         return throwError(() => err)
       })

--- a/src/shared/infrastructure/repositories/decisionS3.repository.spec.ts
+++ b/src/shared/infrastructure/repositories/decisionS3.repository.spec.ts
@@ -10,8 +10,8 @@ import { sdkStreamMixin } from '@smithy/util-stream'
 import 'aws-sdk-client-mock-jest'
 import { DecisionS3Repository } from './decisionS3.repository'
 import { Readable } from 'stream'
-import { Logger } from '@nestjs/common'
 import { BucketError } from '../../domain/errors/bucket.error'
+import { logger } from '../utils/pinoConfig.utils'
 
 describe('DecisionS3Repository', () => {
   let repository: DecisionS3Repository
@@ -21,7 +21,7 @@ describe('DecisionS3Repository', () => {
 
   beforeEach(() => {
     mockS3.reset()
-    repository = new DecisionS3Repository(new Logger())
+    repository = new DecisionS3Repository(logger)
   })
 
   describe('saveDecision', () => {

--- a/src/shared/infrastructure/repositories/decisionS3.repository.spec.ts
+++ b/src/shared/infrastructure/repositories/decisionS3.repository.spec.ts
@@ -11,7 +11,6 @@ import 'aws-sdk-client-mock-jest'
 import { DecisionS3Repository } from './decisionS3.repository'
 import { Readable } from 'stream'
 import { BucketError } from '../../domain/errors/bucket.error'
-import { logger } from '../utils/pinoConfig.utils'
 
 describe('DecisionS3Repository', () => {
   let repository: DecisionS3Repository
@@ -21,7 +20,7 @@ describe('DecisionS3Repository', () => {
 
   beforeEach(() => {
     mockS3.reset()
-    repository = new DecisionS3Repository(logger)
+    repository = new DecisionS3Repository()
   })
 
   describe('saveDecision', () => {

--- a/src/shared/infrastructure/repositories/decisionS3.repository.ts
+++ b/src/shared/infrastructure/repositories/decisionS3.repository.ts
@@ -7,17 +7,16 @@ import {
   ListObjectsV2CommandInput,
   _Object
 } from '@aws-sdk/client-s3'
-import { Logger } from '@nestjs/common'
-import { PinoLogger } from 'nestjs-pino'
 import { CollectDto } from '../dto/collect.dto'
 import { BucketError } from '../../domain/errors/bucket.error'
 import { DecisionRepository } from '../../../api/domain/decisions/repositories/decision.repository'
+import { CustomLogger } from '../utils/pinoConfig.utils'
 
 export class DecisionS3Repository implements DecisionRepository {
   private s3Client: S3Client
-  private logger
+  private logger: CustomLogger
 
-  constructor(logger: PinoLogger | Logger, providedS3Client?: S3Client) {
+  constructor(logger: CustomLogger, providedS3Client?: S3Client) {
     if (providedS3Client) {
       this.s3Client = providedS3Client
     } else {
@@ -49,7 +48,11 @@ export class DecisionS3Repository implements DecisionRepository {
     try {
       await this.s3Client.send(reqParams)
     } catch (error) {
-      this.logger.error({ operationName: 'saveDecision', msg: error.message, data: error })
+      this.logger.error({
+        operations: ['collect', 'decision'],
+        path: './src/shared/infrastructure/repositories/decisionS3.repository.ts',
+        message: JSON.stringify({ msg: error.message, data: error })
+      })
       throw new BucketError(error)
     }
   }
@@ -63,7 +66,11 @@ export class DecisionS3Repository implements DecisionRepository {
     try {
       await this.s3Client.send(new DeleteObjectCommand(reqParams))
     } catch (error) {
-      this.logger.error({ operationName: 'deleteDecision', msg: error.message, data: error })
+      this.logger.error({
+        operations: ['other', 'deleteDecision.decision'],
+        path: './src/shared/infrastructure/repositories/decisionS3.repository.ts',
+        message: JSON.stringify({ msg: error.message, data: error })
+      })
       throw new BucketError(error)
     }
   }
@@ -73,13 +80,16 @@ export class DecisionS3Repository implements DecisionRepository {
       Bucket: process.env.S3_BUCKET_NAME_RAW,
       Key: filename
     }
-
     try {
       const decisionFromS3 = await this.s3Client.send(new GetObjectCommand(reqParams))
       const stringifiedDecision = await decisionFromS3.Body?.transformToString()
       return JSON.parse(stringifiedDecision)
     } catch (error) {
-      this.logger.error({ operationName: 'getDecisionByFilename', msg: error.message, data: error })
+      this.logger.error({
+        operations: ['other', 'getDecisionByFilename.decision'],
+        path: './src/shared/infrastructure/repositories/decisionS3.repository.ts',
+        message: JSON.stringify({ msg: error.message, data: error })
+      })
       throw new BucketError(error)
     }
   }
@@ -100,7 +110,11 @@ export class DecisionS3Repository implements DecisionRepository {
       const decisionListFromS3 = await this.s3Client.send(new ListObjectsV2Command(reqParams))
       return decisionListFromS3.Contents ? decisionListFromS3.Contents : []
     } catch (error) {
-      this.logger.error({ operationName: 'getDecisionList', msg: error.message, data: error })
+      this.logger.error({
+        operations: ['other', 'getDecisionList.decision'],
+        path: './src/shared/infrastructure/repositories/decisionS3.repository.ts',
+        message: JSON.stringify({ msg: error.message, data: error })
+      })
       throw new BucketError(error)
     }
   }

--- a/src/shared/infrastructure/repositories/decisionS3.repository.ts
+++ b/src/shared/infrastructure/repositories/decisionS3.repository.ts
@@ -10,13 +10,12 @@ import {
 import { CollectDto } from '../dto/collect.dto'
 import { BucketError } from '../../domain/errors/bucket.error'
 import { DecisionRepository } from '../../../api/domain/decisions/repositories/decision.repository'
-import { CustomLogger } from '../utils/pinoConfig.utils'
+import { logger } from '../utils/pinoConfig.utils'
 
 export class DecisionS3Repository implements DecisionRepository {
   private s3Client: S3Client
-  private logger: CustomLogger
 
-  constructor(logger: CustomLogger, providedS3Client?: S3Client) {
+  constructor(providedS3Client?: S3Client) {
     if (providedS3Client) {
       this.s3Client = providedS3Client
     } else {
@@ -30,7 +29,6 @@ export class DecisionS3Repository implements DecisionRepository {
         }
       })
     }
-    this.logger = logger
   }
 
   async saveDecisionIntegre(decisionIntegre: Express.Multer.File) {
@@ -48,7 +46,7 @@ export class DecisionS3Repository implements DecisionRepository {
     try {
       await this.s3Client.send(reqParams)
     } catch (error) {
-      this.logger.error({
+      logger.error({
         operations: ['collect', 'decision'],
         path: './src/shared/infrastructure/repositories/decisionS3.repository.ts',
         message: JSON.stringify({ msg: error.message, data: error })
@@ -66,7 +64,7 @@ export class DecisionS3Repository implements DecisionRepository {
     try {
       await this.s3Client.send(new DeleteObjectCommand(reqParams))
     } catch (error) {
-      this.logger.error({
+      logger.error({
         operations: ['other', 'deleteDecision.decision'],
         path: './src/shared/infrastructure/repositories/decisionS3.repository.ts',
         message: JSON.stringify({ msg: error.message, data: error })
@@ -85,7 +83,7 @@ export class DecisionS3Repository implements DecisionRepository {
       const stringifiedDecision = await decisionFromS3.Body?.transformToString()
       return JSON.parse(stringifiedDecision)
     } catch (error) {
-      this.logger.error({
+      logger.error({
         operations: ['other', 'getDecisionByFilename.decision'],
         path: './src/shared/infrastructure/repositories/decisionS3.repository.ts',
         message: JSON.stringify({ msg: error.message, data: error })
@@ -110,7 +108,7 @@ export class DecisionS3Repository implements DecisionRepository {
       const decisionListFromS3 = await this.s3Client.send(new ListObjectsV2Command(reqParams))
       return decisionListFromS3.Contents ? decisionListFromS3.Contents : []
     } catch (error) {
-      this.logger.error({
+      logger.error({
         operations: ['other', 'getDecisionList.decision'],
         path: './src/shared/infrastructure/repositories/decisionS3.repository.ts',
         message: JSON.stringify({ msg: error.message, data: error })

--- a/src/shared/infrastructure/utils/logsFormat.utils.ts
+++ b/src/shared/infrastructure/utils/logsFormat.utils.ts
@@ -1,9 +1,18 @@
-export class LogsFormat {
-  operationName: string
-  msg: string
-  data?: any
-  httpMethod?: string
-  path?: string
-  correlationId?: string | string[]
-  statusCode?: number
+export type DecisionLog = {
+  decision: {
+    _id?: string
+    sourceId: string
+    sourceName: string
+    publishStatus?: string
+    labelStatus?: string
+  }
+  path: string
+  operations: readonly ['collect' | 'extraction' | 'normalization', string]
+  message?: string
+}
+
+export type TechLog = {
+  path: string
+  operations: readonly ['collect' | 'extraction' | 'normalization' | 'other', string]
+  message?: string
 }

--- a/src/shared/infrastructure/utils/pinoConfig.utils.ts
+++ b/src/shared/infrastructure/utils/pinoConfig.utils.ts
@@ -1,9 +1,11 @@
 import { DynamicModule } from '@nestjs/common'
 import { ServerResponse } from 'http'
 import { IncomingMessage } from 'http'
-import { LoggerModule } from 'nestjs-pino'
+import { Logger, LoggerModule } from 'nestjs-pino'
 import { ReqId } from 'pino-http'
 import { v4 as uuidv4 } from 'uuid'
+import { TechLog, DecisionLog } from './logsFormat.utils'
+import { pino } from 'pino'
 
 const pinoPrettyConf = {
   target: 'pino-pretty',
@@ -14,51 +16,47 @@ const pinoPrettyConf = {
   }
 }
 
-export const normalizationPinoConfig = {
-  pinoHttp: {
-    base: { appName: 'JuriTJ-normalization' },
-    formatters: {
-      level: (label) => {
-        return {
-          logLevel: label.toUpperCase()
-        }
+const loggerOptions = {
+  formatters: {
+    level: (label) => {
+      return {
+        logLevel: label.toUpperCase()
       }
     },
-    timestamp: () => `,"timestamp":"${new Date(Date.now()).toISOString()}"`,
-    redact: {
-      paths: ['req', 'res', 'headers', 'ip', 'responseTime', 'hostname', 'pid', 'level'],
-      censor: '',
-      remove: true
-    },
-    transport: process.env.NODE_ENV === 'local' ? pinoPrettyConf : undefined,
-    autoLogging: false
-  }
+    log: (content) => ({
+      ...content,
+      type: Object.keys(content).includes('decison') ? 'decision' : 'tech',
+      appName: 'juritj'
+    })
+  },
+  timestamp: () => `,"timestamp":"${new Date(Date.now()).toISOString()}"`,
+  redact: {
+    paths: ['req', 'res', 'headers', 'ip', 'responseTime', 'hostname', 'pid', 'level'],
+    censor: '',
+    remove: true
+  },
+  genReqId: (request: IncomingMessage, response: ServerResponse): ReqId => {
+    const correlationId = request.headers['x-correlation-id'] ?? uuidv4()
+    request.headers['x-correlation-id'] = correlationId
+    response.setHeader('x-correlation-id', correlationId)
+    return correlationId
+  },
+  autoLogging: false,
+  transport: process.env.NODE_ENV === 'development' ? pinoPrettyConf : undefined
 }
 
 export const configureLoggerModule = (): DynamicModule =>
   LoggerModule.forRoot({
     pinoHttp: {
       base: { appName: 'JuriTJ' },
-      formatters: {
-        level: (label) => {
-          return {
-            logLevel: label.toUpperCase()
-          }
-        }
-      },
-      timestamp: () => `,"timestamp":"${new Date(Date.now()).toISOString()}"`,
-      redact: {
-        paths: ['req', 'res', 'headers', 'ip', 'responseTime', 'hostname', 'pid', 'level'],
-        censor: '',
-        remove: true
-      },
-      transport: process.env.NODE_ENV === 'local' ? pinoPrettyConf : undefined,
-      genReqId: (request: IncomingMessage, response: ServerResponse): ReqId => {
-        const correlationId = request.headers['x-correlation-id'] ?? uuidv4()
-        request.headers['x-correlation-id'] = correlationId
-        response.setHeader('x-correlation-id', correlationId)
-        return correlationId
-      },
-      autoLogging: false
+      ...loggerOptions
     }
   })
+
+export type CustomLogger = Omit<Logger, 'error' | 'warn' | 'info'> & {
+  error: (a: (TechLog | DecisionLog) & Pick<Error, 'stack'>) => void
+  warn: (a: TechLog) => void
+  info: (a: TechLog | DecisionLog) => void
+}
+
+export const logger: CustomLogger = pino(loggerOptions)


### PR DESCRIPTION
Subtilité : On ne peut pas utiliser le format DecisionLog, car nous n'avons que le correlationId pour suivre le flux dans certains cas.
Nous avons deux types de log : techlog => pour logger les erreurs et decisionlog pour logger les informations sur le traitement d'une decision 
```
export type DecisionLog = {
  decision: {
    _id?: string;
    sourceId: string;
    sourceName: string;
    publishStatus?: string;
    labelStatus?: string;
  };
  path: string;
  operations: readonly ['collect' | 'extraction' | 'normalization' | 'other', string];
  message?: string;
};

export type TechLog = {
  path: string;
  operations: readonly ['collect' | 'extraction' | 'normalization' | 'other', string];
  message?: string;
};
```